### PR TITLE
Fixing lookup on graph and BFS on grid

### DIFF
--- a/spec/graph_spec.cr
+++ b/spec/graph_spec.cr
@@ -17,6 +17,14 @@ describe Collections::Graph do
       graph.size.should eq(1)
       node.value.should eq(1)
     end
+
+    it "reuses the existing node when the value is already present" do
+      graph = Collections::Graph(Int32).new
+      first = graph.add_node(1)
+      second = graph.add_node(1)
+      second.should be(first) # same object, not a duplicate
+      graph.size.should eq(1)
+    end
   end
 
   describe "#add_edge" do

--- a/spec/grid_spec.cr
+++ b/spec/grid_spec.cr
@@ -61,6 +61,25 @@ describe Collections::Grid do
     distance[0].should eq(8) if distance
   end
 
+  it "returns a contiguous path including start and goal" do
+    grid = Collections::Grid.new(5, 5, false)
+    start = Collections::Grid::Point.new(0, 0)
+    goal = Collections::Grid::Point.new(4, 4)
+
+    result = grid.shortest_path(start, goal)
+    result.should_not be_nil
+    if result
+      steps, path = result
+      path.first.should eq(start)
+      path.last.should eq(goal)
+      path.size.should eq(steps + 1)
+      # every consecutive pair differs by exactly one orthogonal step
+      path.each_cons(2) do |(a, b)|
+        ((a.x - b.x).abs + (a.y - b.y).abs).should eq(1)
+      end
+    end
+  end
+
   it "finds no path if the goal is blocked" do
     grid = Collections::Grid.new(5, 5, false)
     start = Collections::Grid::Point.new(0, 0)

--- a/src/graph/graph.cr
+++ b/src/graph/graph.cr
@@ -4,14 +4,22 @@ module Collections
   class Graph(T)
     property adjacency_list : Hash(Node(T), Array(Node(T)))
 
+    # Index from value to its canonical Node, so lookups are O(1) instead of
+    # scanning every key in the adjacency list.
+    @nodes : Hash(T, Node(T))
+
     def initialize
       @adjacency_list = {} of Node(T) => Array(Node(T))
+      @nodes = {} of T => Node(T)
     end
 
-    def add_node(value : T)
-      node = Node.new(value)
-      @adjacency_list[node] ||= [] of Node(T)
-      node
+    def add_node(value : T) : Node(T)
+      @nodes.fetch(value) do
+        node = Node.new(value)
+        @nodes[value] = node
+        @adjacency_list[node] = [] of Node(T)
+        node
+      end
     end
 
     def add_edge(value_1 : T, value_2 : T)
@@ -103,7 +111,7 @@ module Collections
     end
 
     private def find_node(value : T) : Node(T)?
-      @adjacency_list.keys.find { |node| node.value == value }
+      @nodes[value]?
     end
   end
 end

--- a/src/grid/grid.cr
+++ b/src/grid/grid.cr
@@ -87,30 +87,42 @@ module Collections
         {0, 1},  # Right
       ]
 
-      queue = [] of Tuple(Int32, Point, Array(Point)) # (distance, point, path)
-      queue << {0, start, [start]}
-      visited = Set(Point).new
+      # BFS. We mark cells visited on enqueue (so each cell is queued at most
+      # once) and reconstruct the path from a came_from map at the end, rather
+      # than carrying a full path copy on every queue entry.
+      queue = Deque(Point){start}
+      visited = Set(Point){start}
+      came_from = {} of Point => Point
 
-      while !queue.empty?
-        distance, point, path = queue.shift
+      until queue.empty?
+        point = queue.shift
+        return reconstruct_path(came_from, start, goal) if point == goal
 
-        # Goal reached
-        return {distance, path} if point == goal
-
-        # Skip if already visited
-        next unless visited.add?(point)
-
-        # Explore neighbors
         directions.each do |dir_x, dir_y|
           nx, ny = point.x + dir_x, point.y + dir_y
+          next if out_of_bounds?(nx, ny) || (filter_blocked && blocked?(nx, ny))
+
           neighbor = Point.new(nx, ny)
-          if !out_of_bounds?(nx, ny) && (!filter_blocked || !blocked?(nx, ny))
-            queue << {distance + 1, neighbor, path + [neighbor]}
-          end
+          next unless visited.add?(neighbor)
+          came_from[neighbor] = point
+          queue << neighbor
         end
       end
 
       nil # No path found
+    end
+
+    # Walk the came_from chain back from goal to start, returning
+    # {number_of_steps, path} with the path ordered start -> goal (inclusive).
+    private def reconstruct_path(came_from : Hash(Point, Point), start : Point, goal : Point) : Tuple(Int32, Array(Point))
+      path = [goal]
+      current = goal
+      while current != start
+        current = came_from[current]
+        path << current
+      end
+      path.reverse!
+      {path.size - 1, path}
     end
 
     def print_grid(path : Array(Point) = [] of Point)


### PR DESCRIPTION
Graph — O(1) node lookup. Added a @nodes : Hash(T, Node(T)) index. find_node is now a hash lookup instead of @adjacency_list.keys.find {...} (was O(n) per call, and it's called inside add_edge, neighbors, remove_edge, and the clique backtracking).

Grid#shortest_path — BFS memory/time fix. Old version used an Array as a queue (shift is O(n)), enqueued neighbors without a visited check (exponential queue growth), and copied the full path into every queue entry.