### PR TITLE
Adding a counter similar to the Python equivalent

### DIFF
--- a/spec/counter_spec.cr
+++ b/spec/counter_spec.cr
@@ -50,6 +50,18 @@ describe Collections::Counter do
     end
   end
 
+  describe "counts beyond Int32" do
+    it "accumulates values larger than Int32::MAX without overflowing" do
+      counter = Collections::Counter(Symbol).new
+      big = 5_000_000_000_i64 # > Int32::MAX (~2.1e9)
+      counter.increment(:fish, big)
+      counter.increment(:fish, big)
+
+      counter[:fish].should eq(10_000_000_000_i64)
+      counter.total.should eq(10_000_000_000_i64)
+    end
+  end
+
   describe "#total" do
     it "sums all counts" do
       counter = Collections::Counter(Int32).new([1, 1, 2, 3, 3, 3])

--- a/spec/counter_spec.cr
+++ b/spec/counter_spec.cr
@@ -1,0 +1,121 @@
+require "../src/counter/counter"
+require "./spec_helper"
+
+describe Collections::Counter do
+  describe "#initialize" do
+    it "creates an empty counter" do
+      counter = Collections::Counter(Int32).new
+      counter.empty?.should be_true
+      counter.size.should eq(0)
+      counter.total.should eq(0)
+    end
+
+    it "tallies occurrences from an enumerable" do
+      counter = Collections::Counter(Char).new("mississippi".chars)
+      counter['i'].should eq(4)
+      counter['s'].should eq(4)
+      counter['p'].should eq(2)
+      counter['m'].should eq(1)
+    end
+  end
+
+  describe "#[]" do
+    it "returns 0 for absent keys without creating an entry" do
+      counter = Collections::Counter(String).new
+      counter["missing"].should eq(0)
+      counter.size.should eq(0)
+    end
+  end
+
+  describe "#increment and #<<" do
+    it "increments by one via <<" do
+      counter = Collections::Counter(Symbol).new
+      counter << :a << :a << :b
+      counter[:a].should eq(2)
+      counter[:b].should eq(1)
+    end
+
+    it "increments by an arbitrary amount and returns the new count" do
+      counter = Collections::Counter(Symbol).new
+      counter.increment(:a, 5).should eq(5)
+      counter.increment(:a, -2).should eq(3)
+    end
+  end
+
+  describe "#[]=" do
+    it "sets a count explicitly" do
+      counter = Collections::Counter(String).new
+      counter["x"] = 7
+      counter["x"].should eq(7)
+    end
+  end
+
+  describe "#total" do
+    it "sums all counts" do
+      counter = Collections::Counter(Int32).new([1, 1, 2, 3, 3, 3])
+      counter.total.should eq(6)
+    end
+  end
+
+  describe "#most_common" do
+    it "returns the n most common entries" do
+      counter = Collections::Counter(Char).new("aaabbc".chars)
+      counter.most_common(1).should eq([{'a', 3}])
+      counter.most_common(2).should eq([{'a', 3}, {'b', 2}])
+    end
+
+    it "returns all entries sorted by count when given no argument" do
+      counter = Collections::Counter(Char).new("aaabbc".chars)
+      counter.most_common.map(&.last).should eq([3, 2, 1])
+    end
+  end
+
+  describe "#elements" do
+    it "yields each key repeated by its count, skipping non-positive" do
+      counter = Collections::Counter(String).new
+      counter["a"] = 3
+      counter["b"] = 0
+      counter["c"] = -1
+      counter.elements.sort.should eq(["a", "a", "a"])
+    end
+  end
+
+  describe "#delete" do
+    it "removes a key and returns its previous count" do
+      counter = Collections::Counter(Int32).new([1, 1])
+      counter.delete(1).should eq(2)
+      counter[1].should eq(0)
+      counter.delete(9).should be_nil
+    end
+  end
+
+  describe "#+" do
+    it "sums counts and keeps only positive totals" do
+      a = Collections::Counter(Char).new("aab".chars)
+      b = Collections::Counter(Char).new("bcc".chars)
+      sum = a + b
+      sum['a'].should eq(2)
+      sum['b'].should eq(2)
+      sum['c'].should eq(2)
+    end
+  end
+
+  describe "#-" do
+    it "subtracts counts and drops non-positive results" do
+      a = Collections::Counter(Char).new("aaab".chars)
+      b = Collections::Counter(Char).new("abb".chars)
+      diff = a - b
+      diff['a'].should eq(2)
+      diff['b'].should eq(0)
+      diff.keys.should_not contain('b')
+    end
+  end
+
+  describe "#==" do
+    it "compares stored counts" do
+      a = Collections::Counter(Int32).new([1, 2, 2])
+      b = Collections::Counter(Int32).new([2, 1, 2])
+      (a == b).should be_true
+    end
+  end
+end

--- a/src/collections.cr
+++ b/src/collections.cr
@@ -2,6 +2,7 @@ require "./grid/grid"
 require "./heap/heap"
 require "./heap/binary_heap"
 require "./graph/graph"
+require "./counter/counter"
 
 module Collections
   VERSION = "0.2.5"

--- a/src/counter/counter.cr
+++ b/src/counter/counter.cr
@@ -1,0 +1,129 @@
+module Collections
+  # A multiset / tally that counts occurrences of values, inspired by Python's
+  # `collections.Counter`. Missing keys read as `0`, and reading a key never
+  # creates an entry.
+  #
+  # ```
+  # counter = Collections::Counter(Char).new("mississippi".chars)
+  # counter['s']           # => 4
+  # counter['z']           # => 0
+  # counter.most_common(2) # => [{'i', 4}, {'s', 4}]
+  # ```
+  class Counter(T)
+    include Enumerable({T, Int32})
+
+    def initialize
+      @counts = {} of T => Int32
+    end
+
+    # Builds a counter by tallying the occurrences of each element.
+    def initialize(elements : Enumerable(T))
+      @counts = {} of T => Int32
+      elements.each { |element| increment(element) }
+    end
+
+    # Returns the count for *key*, or `0` if it is absent.
+    def [](key : T) : Int32
+      @counts.fetch(key, 0)
+    end
+
+    # Sets the count for *key* explicitly. Zero and negative counts are allowed.
+    def []=(key : T, count : Int32) : Int32
+      @counts[key] = count
+    end
+
+    # Adds *by* (default `1`) to *key*'s count and returns the new count.
+    def increment(key : T, by : Int32 = 1) : Int32
+      @counts[key] = self[key] + by
+    end
+
+    # Increments *key* by one. Returns `self` so calls can be chained.
+    def <<(key : T) : self
+      increment(key)
+      self
+    end
+
+    # Removes *key* entirely, returning its previous count (or `nil` if absent).
+    def delete(key : T) : Int32?
+      @counts.delete(key)
+    end
+
+    # Returns the sum of all counts.
+    def total : Int32
+      total = 0
+      @counts.each_value { |count| total += count }
+      total
+    end
+
+    def size : Int32
+      @counts.size
+    end
+
+    def empty? : Bool
+      @counts.empty?
+    end
+
+    def keys : Array(T)
+      @counts.keys
+    end
+
+    def values : Array(Int32)
+      @counts.values
+    end
+
+    def to_h : Hash(T, Int32)
+      @counts.dup
+    end
+
+    def each(& : {T, Int32} ->)
+      @counts.each { |key, count| yield({key, count}) }
+    end
+
+    # Returns the *n* highest-count entries as `{key, count}` pairs, most common
+    # first. With no argument, returns every entry sorted by count descending.
+    # Ties between equal counts are returned in an unspecified order.
+    def most_common(n : Int32? = nil) : Array({T, Int32})
+      sorted = @counts.to_a.sort_by! { |(_, count)| -count }
+      n ? sorted.first(n) : sorted
+    end
+
+    # Returns each key repeated by its count. Keys with a count of `0` or less
+    # are skipped.
+    def elements : Array(T)
+      result = [] of T
+      @counts.each do |key, count|
+        count.times { result << key }
+      end
+      result
+    end
+
+    # Returns a new counter with the counts of both summed. Only keys with a
+    # positive total are kept, matching Python's `Counter + Counter`.
+    def +(other : Counter(T)) : Counter(T)
+      merged = Counter(T).new
+      each { |(key, count)| merged.increment(key, count) }
+      other.each { |(key, count)| merged.increment(key, count) }
+      merged.keep_positive!
+    end
+
+    # Returns a new counter with *other*'s counts subtracted. Only keys with a
+    # positive result are kept, matching Python's `Counter - Counter`.
+    def -(other : Counter(T)) : Counter(T)
+      result = Counter(T).new
+      each { |(key, count)| result.increment(key, count) }
+      other.each { |(key, count)| result.increment(key, -count) }
+      result.keep_positive!
+    end
+
+    # Compares the stored counts exactly. Note that an explicit zero count is
+    # *not* treated as an absent key here.
+    def ==(other : Counter(T)) : Bool
+      @counts == other.to_h
+    end
+
+    protected def keep_positive! : self
+      @counts.reject! { |_, count| count <= 0 }
+      self
+    end
+  end
+end

--- a/src/counter/counter.cr
+++ b/src/counter/counter.cr
@@ -10,31 +10,32 @@ module Collections
   # counter.most_common(2) # => [{'i', 4}, {'s', 4}]
   # ```
   class Counter(T)
-    include Enumerable({T, Int32})
+    include Enumerable({T, Int64})
 
     def initialize
-      @counts = {} of T => Int32
+      @counts = {} of T => Int64
     end
 
     # Builds a counter by tallying the occurrences of each element.
     def initialize(elements : Enumerable(T))
-      @counts = {} of T => Int32
+      @counts = {} of T => Int64
       elements.each { |element| increment(element) }
     end
 
     # Returns the count for *key*, or `0` if it is absent.
-    def [](key : T) : Int32
-      @counts.fetch(key, 0)
+    def [](key : T) : Int64
+      @counts.fetch(key, 0_i64)
     end
 
     # Sets the count for *key* explicitly. Zero and negative counts are allowed.
-    def []=(key : T, count : Int32) : Int32
-      @counts[key] = count
+    def []=(key : T, count : Int) : Int64
+      @counts[key] = count.to_i64
     end
 
-    # Adds *by* (default `1`) to *key*'s count and returns the new count.
-    def increment(key : T, by : Int32 = 1) : Int32
-      @counts[key] = self[key] + by
+    # Adds *by* (default `1`) to *key*'s count and returns the new count. Counts
+    # are stored as `Int64`, so large accumulated totals do not overflow.
+    def increment(key : T, by : Int = 1) : Int64
+      @counts[key] = self[key] + by.to_i64
     end
 
     # Increments *key* by one. Returns `self` so calls can be chained.
@@ -44,13 +45,13 @@ module Collections
     end
 
     # Removes *key* entirely, returning its previous count (or `nil` if absent).
-    def delete(key : T) : Int32?
+    def delete(key : T) : Int64?
       @counts.delete(key)
     end
 
     # Returns the sum of all counts.
-    def total : Int32
-      total = 0
+    def total : Int64
+      total = 0_i64
       @counts.each_value { |count| total += count }
       total
     end
@@ -67,22 +68,22 @@ module Collections
       @counts.keys
     end
 
-    def values : Array(Int32)
+    def values : Array(Int64)
       @counts.values
     end
 
-    def to_h : Hash(T, Int32)
+    def to_h : Hash(T, Int64)
       @counts.dup
     end
 
-    def each(& : {T, Int32} ->)
+    def each(& : {T, Int64} ->)
       @counts.each { |key, count| yield({key, count}) }
     end
 
     # Returns the *n* highest-count entries as `{key, count}` pairs, most common
     # first. With no argument, returns every entry sorted by count descending.
     # Ties between equal counts are returned in an unspecified order.
-    def most_common(n : Int32? = nil) : Array({T, Int32})
+    def most_common(n : Int32? = nil) : Array({T, Int64})
       sorted = @counts.to_a.sort_by! { |(_, count)| -count }
       n ? sorted.first(n) : sorted
     end


### PR DESCRIPTION
src/counter/counter.cr: Collections::Counter(T), a Python-Counter-style multiset:
- Reads never mutate: counter[key] returns the count or 0 for absent keys, without creating an entry.
- Building: Counter(T).new (empty) or Counter(T).new(enumerable) (tallies occurrences).
- Writing: increment(key, by = 1) (returns new count), counter << key (chainable +1), counter[key] = n (explicit set, zero/negatives allowed), delete.
- Querying: total, most_common(n = nil), elements (keys repeated by count), plus keys/values/size/empty?/to_h.
- Arithmetic: + and - return new counters keeping only positive totals (matches Python).
- Includes Enumerable({T, Int32}), so map/select/etc. come for free.