### PR TITLE
Adding a union-find implementation

### DIFF
--- a/spec/disjoint_set_spec.cr
+++ b/spec/disjoint_set_spec.cr
@@ -1,0 +1,86 @@
+require "../src/disjoint_set/disjoint_set"
+require "./spec_helper"
+
+describe Collections::DisjointSet do
+  describe "#initialize" do
+    it "creates an empty structure" do
+      ds = Collections::DisjointSet(Int32).new
+      ds.empty?.should be_true
+      ds.size.should eq(0)
+      ds.count.should eq(0)
+    end
+  end
+
+  describe "#add" do
+    it "registers a value as its own singleton set" do
+      ds = Collections::DisjointSet(Int32).new
+      ds.add(1)
+      ds.includes?(1).should be_true
+      ds.size.should eq(1)
+      ds.count.should eq(1)
+    end
+
+    it "is idempotent" do
+      ds = Collections::DisjointSet(Int32).new
+      ds.add(1)
+      ds.add(1)
+      ds.size.should eq(1)
+      ds.count.should eq(1)
+    end
+  end
+
+  describe "#find" do
+    it "auto-registers an unseen value" do
+      ds = Collections::DisjointSet(String).new
+      ds.find("x").should eq("x")
+      ds.includes?("x").should be_true
+    end
+  end
+
+  describe "#union" do
+    it "merges two sets and reports the merge" do
+      ds = Collections::DisjointSet(Int32).new
+      ds.union(1, 2).should be_true
+      ds.connected?(1, 2).should be_true
+      ds.count.should eq(1)
+    end
+
+    it "returns false when the values are already connected" do
+      ds = Collections::DisjointSet(Int32).new
+      ds.union(1, 2)
+      ds.union(1, 2).should be_false
+      ds.count.should eq(1)
+    end
+
+    it "connects values transitively through a chain of unions" do
+      ds = Collections::DisjointSet(Int32).new
+      ds.union(1, 2)
+      ds.union(2, 3)
+      ds.union(3, 4)
+      ds.connected?(1, 4).should be_true
+      ds.count.should eq(1)
+      ds.size.should eq(4)
+    end
+  end
+
+  describe "#connected?" do
+    it "returns false for values in different sets" do
+      ds = Collections::DisjointSet(Int32).new
+      ds.union(1, 2)
+      ds.connected?(1, 3).should be_false
+    end
+  end
+
+  describe "#subsets" do
+    it "groups every element by its set" do
+      ds = Collections::DisjointSet(Int32).new
+      ds.union(1, 2)
+      ds.union(3, 4)
+      ds.add(5)
+
+      subsets = ds.subsets.map(&.sort).sort_by!(&.first)
+      subsets.should eq([[1, 2], [3, 4], [5]])
+      ds.count.should eq(3)
+    end
+  end
+end

--- a/src/collections.cr
+++ b/src/collections.cr
@@ -2,6 +2,7 @@ require "./grid/grid"
 require "./heap/heap"
 require "./heap/binary_heap"
 require "./graph/graph"
+require "./disjoint_set/disjoint_set"
 
 module Collections
   VERSION = "0.2.5"

--- a/src/disjoint_set/disjoint_set.cr
+++ b/src/disjoint_set/disjoint_set.cr
@@ -1,0 +1,104 @@
+module Collections
+  # A disjoint-set (union-find) structure over arbitrary hashable values, with
+  # path compression and union by rank so `find`/`union` run in near-constant
+  # amortized time.
+  #
+  # Values are added lazily: `find`, `union` and `connected?` all register any
+  # value they are handed that has not been seen before.
+  #
+  # ```
+  # ds = Collections::DisjointSet(Int32).new
+  # ds.union(1, 2)
+  # ds.union(2, 3)
+  # ds.connected?(1, 3) # => true
+  # ds.connected?(1, 4) # => false
+  # ds.count            # => 2  (the set {1, 2, 3} and the singleton {4})
+  # ```
+  class DisjointSet(T)
+    def initialize
+      @parent = {} of T => T
+      @rank = {} of T => Int32
+      @count = 0
+    end
+
+    # Registers *value* as its own singleton set if it is not already present.
+    # Returns `self`.
+    def add(value : T) : self
+      unless @parent.has_key?(value)
+        @parent[value] = value
+        @rank[value] = 0
+        @count += 1
+      end
+      self
+    end
+
+    # Returns the representative of *value*'s set, compressing the path to the
+    # root along the way. Registers *value* first if it is unseen.
+    def find(value : T) : T
+      add(value)
+
+      root = value
+      while @parent[root] != root
+        root = @parent[root]
+      end
+
+      # Path compression: point every node on the way to the root directly at it.
+      while @parent[value] != root
+        parent = @parent[value]
+        @parent[value] = root
+        value = parent
+      end
+
+      root
+    end
+
+    # Merges the sets containing *a* and *b*. Returns `true` if they were in
+    # different sets (and are now merged), or `false` if they were already
+    # together.
+    def union(a : T, b : T) : Bool
+      root_a = find(a)
+      root_b = find(b)
+      return false if root_a == root_b
+
+      # Attach the shorter tree under the taller one (union by rank).
+      root_a, root_b = root_b, root_a if @rank[root_a] < @rank[root_b]
+      @parent[root_b] = root_a
+      @rank[root_a] += 1 if @rank[root_a] == @rank[root_b]
+      @count -= 1
+      true
+    end
+
+    # Returns whether *a* and *b* belong to the same set.
+    def connected?(a : T, b : T) : Bool
+      find(a) == find(b)
+    end
+
+    # Returns whether *value* has been registered.
+    def includes?(value : T) : Bool
+      @parent.has_key?(value)
+    end
+
+    # Returns the number of disjoint sets.
+    def count : Int32
+      @count
+    end
+
+    # Returns the number of registered elements.
+    def size : Int32
+      @parent.size
+    end
+
+    def empty? : Bool
+      @parent.empty?
+    end
+
+    # Returns the members of each disjoint set, one array per set.
+    def subsets : Array(Array(T))
+      groups = {} of T => Array(T)
+      @parent.each_key do |value|
+        (groups[find(value)] ||= [] of T) << value
+      end
+      groups.values
+    end
+  end
+end


### PR DESCRIPTION
src/disjoint_set/disjoint_set.cr: Collections::DisjointSet(T), union-find over any hashable value:
- Near-constant amortized ops via path compression (in find) + union by rank (in union).
- Lazy registration: find/union/connected? auto-register any unseen value, so there's no mandatory make_set step, handy for AoC where you discover nodes as you parse. Explicit add is there too.
- union(a, b) returns true/false (already-connected → false), so you can count merges.
- Introspection: count (number of disjoint sets), size (elements), connected?, includes?, empty?, and subsets : Array(Array(T)) (members grouped per set).