### PR TITLE
Adding a wrapper on the heaps to finalize priorityqueue implementation

### DIFF
--- a/spec/priority_queue_spec.cr
+++ b/spec/priority_queue_spec.cr
@@ -1,0 +1,78 @@
+require "../src/priority_queue/priority_queue"
+require "./spec_helper"
+
+describe Collections::PriorityQueue do
+  describe "#initialize" do
+    it "creates an empty queue" do
+      pq = Collections::PriorityQueue(String, Int32).new
+      pq.empty?.should be_true
+      pq.size.should eq(0)
+    end
+  end
+
+  describe "#push and #pop" do
+    it "pops values lowest-priority first" do
+      pq = Collections::PriorityQueue(String, Int32).new
+      pq.push("low", 5)
+      pq.push("high", 1)
+      pq.push("mid", 3)
+
+      pq.pop.should eq("high")
+      pq.pop.should eq("mid")
+      pq.pop.should eq("low")
+      pq.empty?.should be_true
+    end
+
+    it "chains pushes" do
+      pq = Collections::PriorityQueue(Int32, Int32).new
+      pq.push(10, 2).push(20, 1)
+      pq.size.should eq(2)
+      pq.pop.should eq(20)
+    end
+
+    it "works with float priorities" do
+      pq = Collections::PriorityQueue(Symbol, Float64).new
+      pq.push(:a, 2.5)
+      pq.push(:b, 0.1)
+      pq.pop.should eq(:b)
+    end
+  end
+
+  describe "#pop_entry" do
+    it "returns the value together with its priority" do
+      pq = Collections::PriorityQueue(String, Int32).new
+      pq.push("a", 7)
+      pq.pop_entry.should eq({"a", 7})
+    end
+  end
+
+  describe "#peek" do
+    it "returns the lowest-priority value without removing it" do
+      pq = Collections::PriorityQueue(String, Int32).new
+      pq.push("a", 3)
+      pq.push("b", 1)
+
+      pq.peek.should eq("b")
+      pq.size.should eq(2)
+      pq.peek_entry.should eq({"b", 1})
+    end
+  end
+
+  describe "nil-returning variants" do
+    it "return nil on an empty queue" do
+      pq = Collections::PriorityQueue(String, Int32).new
+      pq.pop?.should be_nil
+      pq.peek?.should be_nil
+      pq.pop_entry?.should be_nil
+      pq.peek_entry?.should be_nil
+    end
+  end
+
+  describe "raising variants" do
+    it "raise IndexError on an empty queue" do
+      pq = Collections::PriorityQueue(String, Int32).new
+      expect_raises(IndexError, "priority queue is empty") { pq.pop }
+      expect_raises(IndexError, "priority queue is empty") { pq.peek }
+    end
+  end
+end

--- a/src/collections.cr
+++ b/src/collections.cr
@@ -2,6 +2,7 @@ require "./grid/grid"
 require "./heap/heap"
 require "./heap/binary_heap"
 require "./graph/graph"
+require "./priority_queue/priority_queue"
 
 module Collections
   VERSION = "0.2.5"

--- a/src/priority_queue/priority_queue.cr
+++ b/src/priority_queue/priority_queue.cr
@@ -1,0 +1,103 @@
+require "../heap/heap"
+require "../heap/binary_heap"
+
+module Collections
+  # A min-priority queue: values are popped lowest-priority-first. Built as a
+  # thin wrapper over `BinaryHeapMin`, so pushes and pops are `O(log n)`.
+  #
+  # The value type `T` and the priority type `P` are independent — `T` need not
+  # be comparable, only `P` (any type whose `<=>` yields a non-nil `Int32`, such
+  # as `Int32`, `Int64` or `Float64`).
+  #
+  # ```
+  # pq = Collections::PriorityQueue(String, Int32).new
+  # pq.push("low", 5)
+  # pq.push("high", 1)
+  # pq.pop # => "high"
+  # ```
+  class PriorityQueue(T, P)
+    # Pairs a value with its priority and orders solely by priority, so the
+    # value itself does not need to be comparable.
+    private struct Entry(T, P)
+      include Comparable(Entry(T, P))
+
+      getter value : T
+      getter priority : P
+
+      def initialize(@value : T, @priority : P)
+      end
+
+      def <=>(other : Entry(T, P)) : Int32
+        result = priority <=> other.priority
+        raise ArgumentError.new("priorities are not comparable") if result.nil?
+        result
+      end
+    end
+
+    def initialize
+      @heap = BinaryHeapMin(Entry(T, P)).new
+    end
+
+    # Adds *value* with the given *priority*. Returns `self` for chaining.
+    def push(value : T, priority : P) : self
+      @heap.add(Entry(T, P).new(value, priority))
+      self
+    end
+
+    # Removes and returns the lowest-priority value. Raises `IndexError` when
+    # the queue is empty.
+    def pop : T
+      pop_entry[0]
+    end
+
+    # Like `#pop`, but returns `nil` when the queue is empty.
+    def pop? : T?
+      pop_entry?.try(&.[0])
+    end
+
+    # Removes and returns the lowest-priority `{value, priority}` pair. Raises
+    # `IndexError` when the queue is empty.
+    def pop_entry : {T, P}
+      raise IndexError.new("priority queue is empty") if empty?
+      entry = @heap.extract_root!
+      {entry.value, entry.priority}
+    end
+
+    # Like `#pop_entry`, but returns `nil` when the queue is empty.
+    def pop_entry? : {T, P}?
+      empty? ? nil : pop_entry
+    end
+
+    # Returns the lowest-priority value without removing it. Raises `IndexError`
+    # when the queue is empty.
+    def peek : T
+      peek_entry[0]
+    end
+
+    # Like `#peek`, but returns `nil` when the queue is empty.
+    def peek? : T?
+      peek_entry?.try(&.[0])
+    end
+
+    # Returns the lowest-priority `{value, priority}` pair without removing it.
+    # Raises `IndexError` when the queue is empty.
+    def peek_entry : {T, P}
+      raise IndexError.new("priority queue is empty") if empty?
+      entry = @heap.extract_root
+      {entry.value, entry.priority}
+    end
+
+    # Like `#peek_entry`, but returns `nil` when the queue is empty.
+    def peek_entry? : {T, P}?
+      empty? ? nil : peek_entry
+    end
+
+    def size : Int32
+      @heap.size
+    end
+
+    def empty? : Bool
+      @heap.size == 0
+    end
+  end
+end


### PR DESCRIPTION
src/priority_queue/priority_queue.cr : Collections::PriorityQueue(T, P), a min-priority queue over your BinaryHeapMin:
- T (value) and P (priority) are independent, the value need not be comparable, only the priority. The private Entry struct is Comparable by priority only, which is the whole reason a raw {priority, value} tuple wouldn't have worked (tuple comparison drags in the value type).
- API: push(value, priority) (chainable); pop/peek return the value; pop_entry/peek_entry return {value, priority} (Dijkstra will want both). Each has a ? variant returning nil on empty; the non-? forms raise IndexError("priority queue is empty").
- Works with Int32, Int64, Float64 priorities.