### PR TITLE
Adding functionality for diagonal elements in grids

### DIFF
--- a/spec/grid_spec.cr
+++ b/spec/grid_spec.cr
@@ -53,6 +53,34 @@ describe Collections::Grid do
     ])
   end
 
+  it "returns diagonal neighbors when requested" do
+    grid = Collections::Grid.new(5, 5, false)
+
+    neighbors = grid.neighbors(2, 2, diagonal: true)
+    neighbors.should eq([
+      Collections::Grid::Point.new(1, 2), # Up
+      Collections::Grid::Point.new(3, 2), # Down
+      Collections::Grid::Point.new(2, 1), # Left
+      Collections::Grid::Point.new(2, 3), # Right
+      Collections::Grid::Point.new(1, 1), # Up-left
+      Collections::Grid::Point.new(1, 3), # Up-right
+      Collections::Grid::Point.new(3, 1), # Down-left
+      Collections::Grid::Point.new(3, 3), # Down-right
+    ])
+  end
+
+  it "clips diagonal neighbors at the grid edge" do
+    grid = Collections::Grid.new(5, 5, false)
+
+    # Corner (0, 0): only in-bounds cells remain.
+    neighbors = grid.neighbors(0, 0, diagonal: true)
+    neighbors.should eq([
+      Collections::Grid::Point.new(1, 0), # Down
+      Collections::Grid::Point.new(0, 1), # Right
+      Collections::Grid::Point.new(1, 1), # Down-right
+    ])
+  end
+
   it "finds the shortest path in an empty grid" do
     grid = Collections::Grid.new(5, 5, false)
     start = Collections::Grid::Point.new(0, 0)

--- a/src/grid/grid.cr
+++ b/src/grid/grid.cr
@@ -46,8 +46,9 @@ module Collections
       get(x, y) != @default_value
     end
 
-    # Get valid neighbors for the given cell
-    def neighbors(x : Int32, y : Int32, filter_blocked : Bool = true) : Array(Point)
+    # Get valid neighbors for the given cell. Orthogonal (up/down/left/right)
+    # by default; pass `diagonal: true` to also include the four diagonal cells.
+    def neighbors(x : Int32, y : Int32, filter_blocked : Bool = true, diagonal : Bool = false) : Array(Point)
       raise ArgumentError.new("Invalid coordinates") if out_of_bounds?(x, y)
 
       directions = [
@@ -57,10 +58,19 @@ module Collections
         {0, 1},  # Right
       ]
 
+      if diagonal
+        directions.concat([
+          {-1, -1}, # Up-left
+          {-1, 1},  # Up-right
+          {1, -1},  # Down-left
+          {1, 1},   # Down-right
+        ])
+      end
+
       directions.compact_map do |dir_x, dir_y|
         nx, ny = x + dir_x, y + dir_y
         Point.new(nx, ny) unless out_of_bounds?(nx, ny) || (filter_blocked && blocked?(nx, ny))
-      end.compact
+      end
     end
 
     # Helper check if the coordinates are out of bounds


### PR DESCRIPTION
src/grid/grid.cr: neighbors gains a diagonal parameter:
- New signature: neighbors(x, y, filter_blocked = true, diagonal = false). The diagonal param is placed after filter_blocked, so every existing call (including the spec's positional neighbors(2, 2, false)) keeps its exact meaning, fully backward compatible.
- diagonal: true appends the four corner offsets (up-left, up-right, down-left, down-right) after the orthogonal four; filter_blocked and bounds-clipping apply uniformly to all 8.
- Small cleanup while I was in there: dropped the trailing .compact, compact_map already removes nils, so it was a redundant second pass.