### PR TITLE
Adding flood-fill for the grid module

### DIFF
--- a/spec/grid_spec.cr
+++ b/spec/grid_spec.cr
@@ -202,4 +202,38 @@ describe Collections::Grid do
       filled.size.should eq(4)
     end
   end
+
+  describe "#region" do
+    it "returns the connected region without modifying the grid" do
+      grid = Collections::Grid.new(3, 3, 0)
+      grid.set(0, 0, 1)
+      grid.set(0, 1, 1)
+      grid.set(1, 0, 1)
+
+      region = grid.region(0, 0)
+      region.map { |point| {point.x, point.y} }.sort!.should eq([{0, 0}, {0, 1}, {1, 0}])
+      # The grid is untouched.
+      grid.get(0, 0).should eq(1)
+      grid.get(0, 1).should eq(1)
+      grid.get(1, 0).should eq(1)
+    end
+
+    it "stops at cells of a different value" do
+      grid = Collections::Grid.new(1, 3, 0)
+      grid.set(0, 0, 1)
+      grid.set(0, 1, 2)
+      grid.set(0, 2, 1)
+
+      grid.region(0, 0).map { |point| {point.x, point.y} }.should eq([{0, 0}])
+    end
+
+    it "spreads across diagonals when requested" do
+      grid = Collections::Grid.new(3, 3, 0)
+      grid.set(0, 0, 1)
+      grid.set(1, 1, 1) # only diagonally adjacent to (0, 0)
+
+      grid.region(0, 0).size.should eq(1)
+      grid.region(0, 0, diagonal: true).size.should eq(2)
+    end
+  end
 end

--- a/spec/grid_spec.cr
+++ b/spec/grid_spec.cr
@@ -154,4 +154,52 @@ describe Collections::Grid do
     distance = grid.shortest_path(start, goal)
     distance.should be_nil # No path exists
   end
+
+  describe "#flood_fill" do
+    it "fills a connected region and returns the filled points" do
+      grid = Collections::Grid.new(3, 3, 0)
+      # A 2x2 block of 1s in the top-left, the rest 0.
+      grid.set(0, 0, 1)
+      grid.set(0, 1, 1)
+      grid.set(1, 0, 1)
+      grid.set(1, 1, 1)
+
+      filled = grid.flood_fill(0, 0, 9)
+      filled.map { |point| {point.x, point.y} }.sort!.should eq([{0, 0}, {0, 1}, {1, 0}, {1, 1}])
+      grid.get(0, 0).should eq(9)
+      grid.get(1, 1).should eq(9)
+      # An untouched cell keeps its value.
+      grid.get(2, 2).should eq(0)
+    end
+
+    it "does not cross a region boundary of a different value" do
+      grid = Collections::Grid.new(1, 3, 0)
+      grid.set(0, 0, 1)
+      grid.set(0, 1, 2) # wall of a different value
+      grid.set(0, 2, 1)
+
+      filled = grid.flood_fill(0, 0, 9)
+      filled.map { |point| {point.x, point.y} }.should eq([{0, 0}])
+      grid.get(0, 2).should eq(1) # unreached
+    end
+
+    it "spreads across diagonals when requested" do
+      grid = Collections::Grid.new(3, 3, 0)
+      grid.set(0, 0, 1)
+      grid.set(1, 1, 1) # only diagonally adjacent to (0, 0)
+
+      orthogonal = Collections::Grid.new(3, 3, 0)
+      orthogonal.set(0, 0, 1)
+      orthogonal.set(1, 1, 1)
+      orthogonal.flood_fill(0, 0, 9).size.should eq(1) # (1,1) not reached
+
+      grid.flood_fill(0, 0, 9, diagonal: true).size.should eq(2) # (1,1) reached
+    end
+
+    it "terminates when the new value equals the target value" do
+      grid = Collections::Grid.new(2, 2, 5)
+      filled = grid.flood_fill(0, 0, 5)
+      filled.size.should eq(4)
+    end
+  end
 end

--- a/src/grid/grid.cr
+++ b/src/grid/grid.cr
@@ -135,6 +135,35 @@ module Collections
       {path.size - 1, path}
     end
 
+    # Flood fills the connected region of cells that share the start cell's
+    # value, replacing each with *new_value*, and returns the filled points in
+    # fill order. Connectivity is orthogonal by default; pass `diagonal: true`
+    # to also spread across diagonals.
+    #
+    # Cells are matched by value (not by `blocked?`), so this works on any grid.
+    def flood_fill(x : Int32, y : Int32, new_value : T, diagonal : Bool = false) : Array(Point)
+      raise ArgumentError.new("Invalid coordinates") if out_of_bounds?(x, y)
+
+      start = Point.new(x, y)
+      target = get(x, y)
+      filled = [] of Point
+      visited = Set(Point){start}
+      queue = Deque(Point){start}
+
+      until queue.empty?
+        point = queue.shift
+        set(point.x, point.y, new_value)
+        filled << point
+
+        neighbors(point.x, point.y, filter_blocked: false, diagonal: diagonal).each do |neighbor|
+          next unless get(neighbor.x, neighbor.y) == target
+          queue << neighbor if visited.add?(neighbor)
+        end
+      end
+
+      filled
+    end
+
     def print_grid(path : Array(Point) = [] of Point)
       path_set = Set(Point).new(path) # Convert path to a set for quick lookup
 

--- a/src/grid/grid.cr
+++ b/src/grid/grid.cr
@@ -135,6 +135,16 @@ module Collections
       {path.size - 1, path}
     end
 
+    # Returns the connected region of cells that share the start cell's value,
+    # in traversal order, without modifying the grid. Connectivity is orthogonal
+    # by default; pass `diagonal: true` to also spread across diagonals.
+    #
+    # Cells are matched by value (not by `blocked?`), so this works on any grid.
+    def region(x : Int32, y : Int32, diagonal : Bool = false) : Array(Point)
+      raise ArgumentError.new("Invalid coordinates") if out_of_bounds?(x, y)
+      collect_region(x, y, diagonal)
+    end
+
     # Flood fills the connected region of cells that share the start cell's
     # value, replacing each with *new_value*, and returns the filled points in
     # fill order. Connectivity is orthogonal by default; pass `diagonal: true`
@@ -144,16 +154,22 @@ module Collections
     def flood_fill(x : Int32, y : Int32, new_value : T, diagonal : Bool = false) : Array(Point)
       raise ArgumentError.new("Invalid coordinates") if out_of_bounds?(x, y)
 
+      filled = collect_region(x, y, diagonal)
+      filled.each { |point| set(point.x, point.y, new_value) }
+      filled
+    end
+
+    # Breadth-first traversal of the connected region sharing (*x*, *y*)'s value.
+    private def collect_region(x : Int32, y : Int32, diagonal : Bool) : Array(Point)
       start = Point.new(x, y)
       target = get(x, y)
-      filled = [] of Point
+      region = [] of Point
       visited = Set(Point){start}
       queue = Deque(Point){start}
 
       until queue.empty?
         point = queue.shift
-        set(point.x, point.y, new_value)
-        filled << point
+        region << point
 
         neighbors(point.x, point.y, filter_blocked: false, diagonal: diagonal).each do |neighbor|
           next unless get(neighbor.x, neighbor.y) == target
@@ -161,7 +177,7 @@ module Collections
         end
       end
 
-      filled
+      region
     end
 
     def print_grid(path : Array(Point) = [] of Point)


### PR DESCRIPTION
src/grid/grid.cr: new flood_fill(x, y, new_value, diagonal = false):
- Classic paint-bucket: replaces the connected region sharing the start cell's value with new_value, returns the filled Points in fill order.
- Matches by value, not blocked? (uses neighbors(..., filter_blocked: false)), so it works on any grid, integer regions, char maps, boolean masks alike.
- Diagonal-aware, reuses the neighbors diagonal: flag.
- Termination is guarded by a visited set, not by the value change, so flood_fill(x, y, same_value) still terminates (and returns the whole region) instead of looping forever, there's a spec for exactly that.
- region returns the connected same-value region without touching the grid, spec asserts the cells keep their original values afterward.
- I extracted the BFS traversal into a private collect_region helper. Now flood_fill = collect_region + set each cell, and region = collect_region returned as-is. Same traversal, one place to maintain.
- flood_fill's observable behavior is unchanged (it now collects-then-sets instead of setting during traversal, equivalent, since matching is by the original value and visited guards revisits). All prior flood_fill specs still pass.