### PR TITLE
Toroidal wrap-around

### DIFF
--- a/spec/grid_spec.cr
+++ b/spec/grid_spec.cr
@@ -81,6 +81,40 @@ describe Collections::Grid do
     ])
   end
 
+  describe "#wrap" do
+    it "wraps coordinates onto the grid" do
+      grid = Collections::Grid.new(5, 5, 0)
+      grid.wrap(-1, 5).should eq(Collections::Grid::Point.new(4, 0))
+      grid.wrap(6, -2).should eq(Collections::Grid::Point.new(1, 3))
+      grid.wrap(2, 3).should eq(Collections::Grid::Point.new(2, 3))
+    end
+  end
+
+  it "returns wrapped neighbors on a torus" do
+    grid = Collections::Grid.new(5, 5, false)
+
+    # Corner (0, 0): orthogonal neighbors wrap to the opposite edges.
+    neighbors = grid.neighbors(0, 0, toroidal: true)
+    neighbors.should eq([
+      Collections::Grid::Point.new(4, 0), # Up wraps to bottom
+      Collections::Grid::Point.new(1, 0), # Down
+      Collections::Grid::Point.new(0, 4), # Left wraps to right
+      Collections::Grid::Point.new(0, 1), # Right
+    ])
+  end
+
+  it "deduplicates wrapped neighbors and excludes the origin on tiny grids" do
+    grid = Collections::Grid.new(2, 2, false)
+
+    # On a 2x2 torus, opposite orthogonal neighbors coincide.
+    neighbors = grid.neighbors(0, 0, toroidal: true)
+    neighbors.should eq([
+      Collections::Grid::Point.new(1, 0),
+      Collections::Grid::Point.new(0, 1),
+    ])
+    neighbors.should_not contain(Collections::Grid::Point.new(0, 0))
+  end
+
   it "finds the shortest path in an empty grid" do
     grid = Collections::Grid.new(5, 5, false)
     start = Collections::Grid::Point.new(0, 0)

--- a/src/grid/grid.cr
+++ b/src/grid/grid.cr
@@ -48,7 +48,12 @@ module Collections
 
     # Get valid neighbors for the given cell. Orthogonal (up/down/left/right)
     # by default; pass `diagonal: true` to also include the four diagonal cells.
-    def neighbors(x : Int32, y : Int32, filter_blocked : Bool = true, diagonal : Bool = false) : Array(Point)
+    #
+    # Pass `toroidal: true` to treat the grid as a torus: neighbors wrap across
+    # the edges (via `#wrap`) instead of being clipped. On small grids where
+    # opposite neighbors land on the same cell, the result is deduplicated and
+    # the origin cell itself is never included.
+    def neighbors(x : Int32, y : Int32, filter_blocked : Bool = true, diagonal : Bool = false, toroidal : Bool = false) : Array(Point)
       raise ArgumentError.new("Invalid coordinates") if out_of_bounds?(x, y)
 
       directions = [
@@ -67,10 +72,30 @@ module Collections
         ])
       end
 
-      directions.compact_map do |dir_x, dir_y|
+      origin = Point.new(x, y)
+      result = directions.compact_map do |dir_x, dir_y|
         nx, ny = x + dir_x, y + dir_y
-        Point.new(nx, ny) unless out_of_bounds?(nx, ny) || (filter_blocked && blocked?(nx, ny))
+        if toroidal
+          point = wrap(nx, ny)
+          next if point == origin
+          point unless filter_blocked && blocked?(point.x, point.y)
+        else
+          Point.new(nx, ny) unless out_of_bounds?(nx, ny) || (filter_blocked && blocked?(nx, ny))
+        end
       end
+
+      toroidal ? result.uniq : result
+    end
+
+    # Wraps a coordinate onto the grid, so values off one edge reappear on the
+    # opposite edge (toroidal / wrap-around indexing).
+    #
+    # ```
+    # grid = Collections::Grid.new(5, 5, 0)
+    # grid.wrap(-1, 5) # => Point(4, 0)
+    # ```
+    def wrap(x : Int32, y : Int32) : Point
+      Point.new(x % @rows, y % @cols)
     end
 
     # Helper check if the coordinates are out of bounds


### PR DESCRIPTION
src/grid/grid.cr: two additions:
- wrap(x, y) : Point,  the core primitive; normalizes any coordinate onto the grid via floored modulo, so off-edge coords reappear on the opposite edge.
- neighbors gains toroidal: true (placed after diagonal, so all existing calls are unaffected). When set, neighbors wrap across edges instead of clipping. Two correctness details for small grids: results are deduped (on a 2×2 torus, up and down land on the same cell) and the origin cell is excluded (on a 1×1 everything wraps to self). Spec covers both.