### PR TITLE
adds a from string parser for grids

### DIFF
--- a/spec/grid_spec.cr
+++ b/spec/grid_spec.cr
@@ -81,6 +81,44 @@ describe Collections::Grid do
     ])
   end
 
+  describe ".from_string" do
+    it "builds a Char grid from a multi-line string" do
+      grid = Collections::Grid(Char).from_string("#..\n.#.\n..#")
+      grid.rows.should eq(3)
+      grid.cols.should eq(3)
+      grid.get(0, 0).should eq('#')
+      grid.get(1, 1).should eq('#')
+      grid.get(0, 1).should eq('.')
+    end
+
+    it "uses the default value for blocked? semantics" do
+      grid = Collections::Grid(Char).from_string("#.\n..")
+      grid.blocked?(0, 0).should be_true  # '#' differs from default '.'
+      grid.blocked?(0, 1).should be_false # '.' is the default
+    end
+
+    it "maps characters to arbitrary values via a block" do
+      grid = Collections::Grid(Int32).from_string("12\n34", 0) { |char, _x, _y| char.to_i }
+      grid.get(0, 0).should eq(1)
+      grid.get(0, 1).should eq(2)
+      grid.get(1, 0).should eq(3)
+      grid.get(1, 1).should eq(4)
+    end
+
+    it "handles ragged lines by padding with the default" do
+      grid = Collections::Grid(Char).from_string("abc\nde")
+      grid.rows.should eq(2)
+      grid.cols.should eq(3) # widest line
+      grid.get(1, 1).should eq('e')
+      grid.get(1, 2).should eq('.') # past the end of the short row -> default
+    end
+
+    it "accepts a custom default value" do
+      grid = Collections::Grid(Char).from_string("ab\nc", '#')
+      grid.get(1, 1).should eq('#') # unset ragged cell falls back to custom default
+    end
+  end
+
   it "finds the shortest path in an empty grid" do
     grid = Collections::Grid.new(5, 5, false)
     start = Collections::Grid::Point.new(0, 0)

--- a/src/grid/grid.cr
+++ b/src/grid/grid.cr
@@ -32,6 +32,40 @@ module Collections
       @cells = Hash(Point, T).new
     end
 
+    # Builds a grid from a multi-line string, mapping each character to a cell
+    # value via the block. Each line becomes a row (x), each column a `y`; the
+    # grid width is the length of the longest line, and shorter rows are left at
+    # *default_value*.
+    #
+    # ```
+    # grid = Collections::Grid(Int32).from_string("12\n34", 0) { |char, _x, _y| char.to_i }
+    # grid.get(1, 1) # => 4
+    # ```
+    def self.from_string(text : String, default_value : T, & : Char, Int32, Int32 -> T) : Grid(T)
+      lines = text.lines
+      cols = lines.max_of?(&.size) || 0
+      grid = new(lines.size, cols, default_value)
+
+      lines.each_with_index do |line, x|
+        line.each_char_with_index do |char, y|
+          grid.set(x, y, yield(char, x, y))
+        end
+      end
+
+      grid
+    end
+
+    # Builds a `Grid(Char)` from a multi-line string, one character per cell.
+    # *default_value* is the value returned for cells outside a ragged row.
+    #
+    # ```
+    # grid = Collections::Grid(Char).from_string("#..\n.#.")
+    # grid.get(1, 1) # => '#'
+    # ```
+    def self.from_string(text : String, default_value : Char = '.') : Grid(Char)
+      Grid(Char).from_string(text, default_value) { |char, _x, _y| char }
+    end
+
     def set(x : Int32, y : Int32, value : T)
       raise ArgumentError.new("Invalid coordinates") if out_of_bounds?(x, y)
       @cells[Point.new(x, y)] = value


### PR DESCRIPTION
src/grid/grid.cr: two self.from_string overloads:
- Grid(Char).from_string(text), zero-config char map; each char becomes a cell. Optional custom default_value (default '.'), which also drives blocked? semantics.
- Grid(T).from_string(text, default) { |char, x, y| ... }, block form mapping each char to any T (the doctest builds an Int32 digit grid).
- Convention: line index = row (x), column = y, consistent with get/set/print_grid. Ragged lines are handled: width = longest line; cells past a short row fall back to the default (spec covers this).
- The Char overload just delegates to the block overload with an identity block, one code path.