### PR TITLE
Adding weighted graph support and Dijkstra for shortest distance

### DIFF
--- a/spec/weighted_graph_spec.cr
+++ b/spec/weighted_graph_spec.cr
@@ -1,0 +1,111 @@
+require "../src/weighted_graph/weighted_graph"
+require "./spec_helper"
+
+describe Collections::WeightedGraph do
+  describe "#initialize" do
+    it "creates an empty graph" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.empty?.should be_true
+      graph.size.should eq(0)
+    end
+  end
+
+  describe "#add_edge" do
+    it "adds undirected edges by default" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_edge("a", "b", 4)
+
+      graph.weight("a", "b").should eq(4)
+      graph.weight("b", "a").should eq(4)
+      graph.nodes.sort.should eq(["a", "b"])
+    end
+
+    it "adds a one-way edge when directed" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_edge("a", "b", 4, directed: true)
+
+      graph.weight("a", "b").should eq(4)
+      graph.weight("b", "a").should be_nil
+    end
+
+    it "overwrites the weight when re-adding an edge" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_edge("a", "b", 4)
+      graph.add_edge("a", "b", 1)
+      graph.weight("a", "b").should eq(1)
+    end
+  end
+
+  describe "#neighbors" do
+    it "returns the neighbor-to-weight map" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_edge("a", "b", 1)
+      graph.add_edge("a", "c", 2)
+      graph.neighbors("a").should eq({"b" => 1, "c" => 2})
+    end
+
+    it "returns an empty map for an absent node" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.neighbors("missing").should be_empty
+    end
+  end
+
+  describe "#dijkstra" do
+    it "returns shortest distances to all reachable nodes" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_edge("a", "b", 1)
+      graph.add_edge("b", "c", 1)
+      graph.add_edge("a", "c", 5)
+
+      distances = graph.dijkstra("a")
+      distances.should eq({"a" => 0, "b" => 1, "c" => 2})
+    end
+
+    it "omits unreachable nodes" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_edge("a", "b", 1)
+      graph.add_node("island")
+
+      distances = graph.dijkstra("a")
+      distances.has_key?("island").should be_false
+    end
+  end
+
+  describe "#shortest_path" do
+    it "prefers a cheaper multi-hop path over an expensive direct edge" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_edge("a", "b", 1)
+      graph.add_edge("b", "c", 1)
+      graph.add_edge("a", "c", 5)
+
+      graph.shortest_path("a", "c").should eq({2, ["a", "b", "c"]})
+    end
+
+    it "returns a zero-length path from a node to itself" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_node("a")
+      graph.shortest_path("a", "a").should eq({0, ["a"]})
+    end
+
+    it "returns nil when the target is unreachable" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_edge("a", "b", 1)
+      graph.add_node("c")
+      graph.shortest_path("a", "c").should be_nil
+    end
+
+    it "respects edge direction" do
+      graph = Collections::WeightedGraph(String, Int32).new
+      graph.add_edge("a", "b", 1, directed: true)
+      graph.shortest_path("a", "b").should eq({1, ["a", "b"]})
+      graph.shortest_path("b", "a").should be_nil
+    end
+
+    it "works with float weights" do
+      graph = Collections::WeightedGraph(Symbol, Float64).new
+      graph.add_edge(:a, :b, 1.5)
+      graph.add_edge(:b, :c, 2.0)
+      graph.shortest_path(:a, :c).should eq({3.5, [:a, :b, :c]})
+    end
+  end
+end

--- a/src/collections.cr
+++ b/src/collections.cr
@@ -3,6 +3,7 @@ require "./heap/heap"
 require "./heap/binary_heap"
 require "./graph/graph"
 require "./priority_queue/priority_queue"
+require "./weighted_graph/weighted_graph"
 
 module Collections
   VERSION = "0.2.5"

--- a/src/weighted_graph/weighted_graph.cr
+++ b/src/weighted_graph/weighted_graph.cr
@@ -1,0 +1,138 @@
+require "../priority_queue/priority_queue"
+
+module Collections
+  # A graph whose edges carry weights, with Dijkstra shortest-path search built
+  # on `PriorityQueue`. `T` is the node/value type (any hashable value) and `W`
+  # is the weight type (a non-negative numeric type such as `Int32` or
+  # `Float64`).
+  #
+  # Edges are undirected by default; pass `directed: true` to add a one-way edge.
+  #
+  # ```
+  # graph = Collections::WeightedGraph(String, Int32).new
+  # graph.add_edge("a", "b", 1)
+  # graph.add_edge("b", "c", 2)
+  # graph.shortest_path("a", "c") # => {3, ["a", "b", "c"]}
+  # ```
+  #
+  # NOTE: Dijkstra assumes non-negative weights; negative edges are not
+  # supported.
+  class WeightedGraph(T, W)
+    getter adjacency : Hash(T, Hash(T, W))
+
+    def initialize
+      @adjacency = Hash(T, Hash(T, W)).new
+    end
+
+    # Registers *value* as a node if it is not already present, and returns its
+    # (possibly newly created) outgoing-edge map.
+    def add_node(value : T) : Hash(T, W)
+      @adjacency[value] ||= {} of T => W
+    end
+
+    # Adds an edge from *from* to *to* with the given *weight*. Undirected by
+    # default (the reverse edge is added too); pass `directed: true` for a
+    # one-way edge. Re-adding an existing edge overwrites its weight.
+    def add_edge(from : T, to : T, weight : W, directed : Bool = false) : Nil
+      add_node(from)
+      add_node(to)
+      @adjacency[from][to] = weight
+      @adjacency[to][from] = weight unless directed
+    end
+
+    # Returns the outgoing edges of *value* as a `{neighbor => weight}` map, or
+    # an empty map if the node is absent.
+    def neighbors(value : T) : Hash(T, W)
+      @adjacency[value]? || {} of T => W
+    end
+
+    # Returns the weight of the edge from *from* to *to*, or `nil` if there is
+    # no such edge.
+    def weight(from : T, to : T) : W?
+      @adjacency[from]?.try &.[to]?
+    end
+
+    def nodes : Array(T)
+      @adjacency.keys
+    end
+
+    def size : Int32
+      @adjacency.size
+    end
+
+    def empty? : Bool
+      @adjacency.empty?
+    end
+
+    # Runs Dijkstra from *source*, returning the shortest distance to every
+    # reachable node (including *source* itself at distance zero). Unreachable
+    # nodes are simply absent from the result.
+    def dijkstra(source : T) : Hash(T, W)
+      distances = {} of T => W
+      return distances unless @adjacency.has_key?(source)
+
+      distances[source] = W.zero
+      queue = PriorityQueue(T, W).new
+      queue.push(source, W.zero)
+
+      until queue.empty?
+        node, distance = queue.pop_entry
+        # Skip stale queue entries superseded by a shorter path.
+        next if distance > distances[node]
+
+        neighbors(node).each do |neighbor, edge_weight|
+          candidate = distance + edge_weight
+          if !distances.has_key?(neighbor) || candidate < distances[neighbor]
+            distances[neighbor] = candidate
+            queue.push(neighbor, candidate)
+          end
+        end
+      end
+
+      distances
+    end
+
+    # Returns the shortest path from *source* to *target* as
+    # `{total_distance, [source, ..., target]}`, or `nil` if *target* is
+    # unreachable (or either node is absent).
+    def shortest_path(source : T, target : T) : {W, Array(T)}?
+      return unless @adjacency.has_key?(source) && @adjacency.has_key?(target)
+
+      distances = {} of T => W
+      previous = {} of T => T
+      distances[source] = W.zero
+      queue = PriorityQueue(T, W).new
+      queue.push(source, W.zero)
+
+      until queue.empty?
+        node, distance = queue.pop_entry
+        next if distance > distances[node]
+        break if node == target # its distance is now final
+
+        neighbors(node).each do |neighbor, edge_weight|
+          candidate = distance + edge_weight
+          if !distances.has_key?(neighbor) || candidate < distances[neighbor]
+            distances[neighbor] = candidate
+            previous[neighbor] = node
+            queue.push(neighbor, candidate)
+          end
+        end
+      end
+
+      return unless distances.has_key?(target)
+      {distances[target], reconstruct_path(previous, source, target)}
+    end
+
+    # Walks the `previous` chain back from target to source, returning the path
+    # ordered source -> target (inclusive).
+    private def reconstruct_path(previous : Hash(T, T), source : T, target : T) : Array(T)
+      path = [target]
+      current = target
+      while current != source
+        current = previous[current]
+        path << current
+      end
+      path.reverse!
+    end
+  end
+end


### PR DESCRIPTION
src/weighted_graph/weighted_graph.cr: Collections::WeightedGraph(T, W):
- Separate class, the existing unweighted Graph is untouched. T = node (any hashable value), W = weight (non-negative numeric: Int32, Int64, Float64).
- Structure: Hash(T, Hash(T, W)) (from → to → weight). add_edge(from, to, weight, directed: false), undirected by default like your Graph; re-adding overwrites the weight. Plus neighbors, weight, nodes, size, empty?.
- dijkstra(source) : Hash(T, W), shortest distance to every reachable node (source at W.zero; unreachable nodes simply absent).
- shortest_path(source, target) : {W, Array(T)}?, {distance, [source..target]}, or nil if unreachable. Path rebuilt from a previous map, mirroring the Grid BFS style.

- Built directly on the merged PriorityQueue(T, W) — pop_entry gives back {node, distance}
- Start distance uses W.zero (verified Int32.zero/Float64.zero → the additive identity), which is what keeps it generic over int and float weights.
- Non-negative weights only — documented in the class comment; Dijkstra can't handle negative edges. If we ever want negative-edge support that'd be a separate Bellman-Ford.